### PR TITLE
EF Migration cli init

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddWebServices();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment() && args.Contains("--init"))
 {
     await app.InitialiseDatabaseAsync();
 }


### PR DESCRIPTION
> ## TL;DR
> This pull request modifies the `Program.cs` file to only initialize the database in the development environment when the `--init` argument is passed.
> 
> ## What changed
> The condition to initialize the database in the development environment was changed. Previously, the database was initialized every time the application was run in the development environment. Now, it will only be initialized if the `--init` argument is passed when running the application.
> 
> A minor change was also made to remove an unnecessary line break.
> 
> ## How to test
> To test this change, run the application in the development environment with and without the `--init` argument. When the `--init` argument is passed, the database should be initialized. When it is not passed, the database should not be initialized.
> 
> ## Why make this change
> This change was made to give developers more control over when the database is initialized. This can be useful in situations where the developer does not want to reset the database every time they run the application.
</details>